### PR TITLE
Suppress success message

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,12 @@ module.exports = function (options, logger) {
 
 		lint.on('close', function (code, signal) {
       // suppress success message
-      if(code) {
+      // we should be able to test the exit code
+      // but stylint does not respect exit codes - always zero
+      // use this test if stylint is updated to respect exit code
+      // if(code) {
+      // so this messy hack instead
+      if(!/all clear!\s+/.test(warnings)) {
 			  logger(warnings);
       }
 			this.push(file);

--- a/index.js
+++ b/index.js
@@ -39,8 +39,11 @@ module.exports = function (options, logger) {
 			gutil.log('gulp-stylint: stderr:', data.toString());
 		});
 
-		lint.on('close', function (data) {
-			logger(warnings);
+		lint.on('close', function (code, signal) {
+      // suppress success message
+      if(code) {
+			  logger(warnings);
+      }
 			this.push(file);
 			cb();
 		}.bind(this));


### PR DESCRIPTION
When `stylint` passes the success message with the emoji unnecessarily clutters the gulp output.

I tried to test the exit code, but `stylint` does not respect the exit code, in the meantime a crude hack to show warnings/errors but suppress the success message.
