### PR TITLE
Call Stylint programatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "dependencies": {
     "gulp-util": "^3.0.0",
     "stylint": "^1.0.9",
-    "through2": "^0.6.1",
-    "win-spawn": "^2.0.0"
+    "through2": "^0.6.1"
   },
   "devDependencies": {
     "jshint": "^2.8.0",

--- a/test.js
+++ b/test.js
@@ -3,19 +3,24 @@
 'use strict';
 
 var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
 var gutil = require('gulp-util');
 var sinon = require('sinon');
 var stylint = require('./');
 var stream;
 
 function file (filename) {
-	stream.write(new gutil.File({
-		base: __dirname,
-		path: __dirname + '/fixtures/' + filename,
-		contents: new Buffer('')
-	}));
-	stream.on('data', function () {});
-	stream.end();
+	var pathToFile = path.resolve('fixtures', filename);
+
+	fs.readFile(pathToFile, function (err, data) {
+		stream.write(new gutil.File({
+			path: pathToFile,
+			contents: data
+		}));
+		stream.on('data', function () {});
+		stream.end();
+	});
 }
 
 it('It should not log if file is valid', function (cb) {


### PR DESCRIPTION
Heavily inspired by https://github.com/xdissent/grunt-stylint.

The use case for this is to capture the original strings instead of listening to `stdout` and `stderr`, as those lose colors.

![image](https://cloud.githubusercontent.com/assets/1404810/8768395/f5a3508c-2e7e-11e5-8714-1caacd60f696.png)

![image](https://cloud.githubusercontent.com/assets/1404810/8768388/cb09c7d4-2e7e-11e5-8207-1619900ff731.png)

In addition I also think it feels less hackish than to spawn up the CLI. It's a shame that stylint's API isn't the cleanest. And the fact that it calls console.log on every violation
