### PR TITLE
Fix: TypeError: Cannot convert undefined or null to object

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,13 @@ var stylint = require('stylint');
 
 module.exports = function (options, logger) {
 	logger = logger || console.log;
-	options = options || {};
-	var failOnError = options.failOnError;
 
-	delete options.failOnError;
+	var failOnError;
+
+	if (options) {
+		failOnError = options.failOnError;
+		delete options.failOnError;
+	}
 
 	return through.obj(function (file, enc, cb) {
 		var that = this;
@@ -18,9 +21,6 @@ module.exports = function (options, logger) {
 		}
 		if (file.isStream()) {
 			return cb(gutil.PluginError('gulp-stylint', 'Streaming not supported'), file);
-		}
-		if (Object.keys(options).length < 1) {
-			options = undefined;
 		}
 
 		stylint(file.path, options)

--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ module.exports = function (options, logger) {
 	if (options) {
 		failOnError = options.failOnError;
 		delete options.failOnError;
+
+		if (Object.keys(options).length === 0) {
+			options = undefined;
+		}
 	}
 
 	return through.obj(function (file, enc, cb) {

--- a/index.js
+++ b/index.js
@@ -5,10 +5,17 @@ var stylint = require('stylint');
 
 module.exports = function (options, logger) {
 	logger = logger || console.log;
-	options = options || {};
-	var failOnError = options.failOnError;
 
-	delete options.failOnError;
+	var failOnError;
+
+	if (options) {
+		failOnError = options.failOnError;
+		delete options.failOnError;
+
+		if (Object.keys(options).length === 0) {
+			options = undefined;
+		}
+	}
 
 	return through.obj(function (file, enc, cb) {
 		var that = this;
@@ -18,9 +25,6 @@ module.exports = function (options, logger) {
 		}
 		if (file.isStream()) {
 			return cb(gutil.PluginError('gulp-stylint', 'Streaming not supported'), file);
-		}
-		if (Object.keys(options).length < 1) {
-			options = undefined;
 		}
 
 		stylint(file.path, options)


### PR DESCRIPTION
Fix the following error

```
/somewhere/node_modules/gulp-stylint/index.js:22
        if (Object.keys(options).length < 1) {
                   ^
TypeError: Cannot convert undefined or null to object
    at Function.keys (native)
    at DestroyableTransform._transform (/somewhere/node_modules/gulp-stylint/index.js:22:14)
    at DestroyableTransform.Transform._read (/somewhere/node_modules/gulp-stylint/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/somewhere/node_modules/gulp-stylint/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/somewhere/node_modules/gulp-stylint/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/somewhere/node_modules/gulp-stylint/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (/somewhere/node_modules/gulp-stylint/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at write (/somewhere/node_modules/gulp/node_modules/vinyl-fs/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/somewhere/node_modules/gulp/node_modules/vinyl-fs/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:632:7)
    at DestroyableTransform.pipeOnReadable (/somewhere/node_modules/gulp/node_modules/vinyl-fs/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:664:5)
```
