### PR TITLE
Added failing test to demonstrate the issue with #13

### DIFF
--- a/test.js
+++ b/test.js
@@ -65,6 +65,20 @@ it('It should not log if file is valid with custom options', function (cb) {
 	file('novalid.styl');
 });
 
+it('It should log if file is invalid with custom options', function (cb) {
+	var log = sinon.spy();
+	stream = stylint({
+		config: 'config/.stylintrc'
+	}, log);
+
+	stream.on('end', function () {
+		assert(log.called);
+		cb();
+	});
+
+	file('valid.styl');
+});
+
 it('It should fail if option is provided', function (cb) {
 	var log = sinon.spy();
 	stream = stylint({


### PR DESCRIPTION
The tests didn't test to determine if an alternative configuration would
cause errors/warnings where appropriate. I added a simple test that is
proving that the alternative config is not causing errors/warnings where
it should. The test should probably be fleshed out more, though.
