### PR TITLE
Allow custom reporter in addition to custom rules

### DIFF
--- a/config/.stylintrc
+++ b/config/.stylintrc
@@ -1,3 +1,4 @@
+// Comments rock!
 {
 	"colons": "always",
 	"semicolons": "always",

--- a/package.json
+++ b/package.json
@@ -27,12 +27,14 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "stylint": "^1.0.9",
+    "stylint": "^1.0.11",
     "through2": "^0.6.1"
   },
   "devDependencies": {
+    "chalk": "^1.1.0",
     "jshint": "^2.8.0",
     "mocha": "*",
-    "sinon": "^1.13.0"
+    "sinon": "^1.13.0",
+    "stylint-stylish": "^1.2.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -44,10 +44,43 @@ type: `object`
 
 ##### config
 
-Type: `string` or `object`  
+Type: `string`  
 Default: `undefined`
 
-Pass in path to custom rules configuration file as a string or include the rules inline as an object. If no configuration is passed in, it will use the `.stylintrc` file in the project root if present. If that file is not present, it will use default rules.
+Pass in path to custom rules configuration file as a string. If no configuration is passed in, it will use the `.stylintrc` file in the project root if present. If that file is not present, it will use default rules.
+
+##### rules
+
+type: `object`  
+Default: `undefined`
+
+Pass in an object with rules for `stylint` to lint by. This will override all default rules.
+
+##### reporter
+
+type: `string or object`  
+Default: `undefined`
+
+If using `rules`, and you want to use a custom reporter, you can pass in either a string with it's name, or an object containing both a string with the name, and options for it.  
+If you only pass in `config`, this config can be placed in that file instead.
+
+Example:
+```js
+gulp.task('default', function () {
+  return gulp.src('src/*.styl')
+    .pipe(stylint({
+      rules: { semicolons: 'always' },
+      reporter: {
+        reporter: 'stylint-stylish',
+        reporterOptions: {
+          verbose: true
+        }
+      }
+    }));
+}
+```
+
+__NOTE__: You must install the reporter yourself. E.g. `npm i -D stylint-stylish`.
 
 ##### failOnError
 


### PR DESCRIPTION
I'm not really happy with this implementation... It's getting late though, and a lot of stuff going on at work, so difficult to spend the time I'd like on this atm.
Anyways, thoughts on the implementation?

This'll probably be eclipsed by #16, but this is a smaller change, so I thought I'd get that out first.

Changes are:
- `config`-option is only string again (technically breaking change...)
- We do not read the config-file, stylint itself takes care of that
- To pass custom rules, use `rules` (and not `config`)
- New option called `reporter`

/cc @joezimjs 
