### PR TITLE
Split reporter from linting, adding a separate fail-reporter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,14 @@
+# [master](https://github.com/danielhusar/gulp-stylint/compare/v2.0.0...master) (unreleased)
+## Breaking changes
+* Just piping the files through `gulp-stylint` does not print anything to the console, use the `csslint.reporter`-method
+
+## Features
+* Added a `fail`-reporter allowing you to fail the proecss on `error`. Optionally provide `{ failOnWarning: true }` as second option to alsow fail on warnings
+
+# [2.0.0](https://github.com/danielhusar/gulp-stylint/compare/v1.1.10...v2.0.0) (2015-08-12)
+## Breaking changes
+* Config option only allows a string
+
+## Features
+* Pass custom rules to stylint using the `rules` option
+* Add `reporter` option to supply a custom reporter. Usse this if you cannot have the reporter in `.stylintrc`

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ var stylint = require('gulp-stylint');
 gulp.task('default', function () {
 	return gulp.src('src/*.styl')
 		.pipe(stylint())
+		.pipe(stylint.reporter());
 });
 ```
 
@@ -31,13 +32,82 @@ var stylint = require('gulp-stylint');
 gulp.task('default', function () {
 	return gulp.src('src/*.styl')
 		.pipe(stylint({config: '.stylintrc'}))
+		.pipe(stylint.reporter());
 });
 ```
 
+## Reporters
+
+### Standard
+Standard reporter is just printing out the report created from `stylint` (possibly formatted by #reporter).
+
+```js
+var gulp = require('gulp');
+var stylint = require('gulp-stylint');
+
+gulp.task('default', function () {
+	return gulp.src('src/*.styl')
+		.pipe(stylint())
+		.pipe(stylint.reporter());
+});
+```
+
+#### Reporter options
+
+##### logger
+Type: `function`  
+Default: `console.log`
+
+Default warnings log function, you can use for example `gutil.log`.
+
+```js
+var gulp = require('gulp');
+var stylint = require('gulp-stylint');
+
+gulp.task('default', function () {
+	return gulp.src('src/*.styl')
+		.pipe(stylint())
+		.pipe(stylint.reporter({ logger: gutil.log.bind(null, 'gulp-stylint:') }));
+});
+```
+
+### Fail-reporter
+Another reporter you can use is the `fail-reporter`. You can use it to fail the `gulp`-process in the case of linting-errors, or optionally warnings.
+
+```js
+var gulp = require('gulp');
+var stylint = require('gulp-stylint');
+
+gulp.task('default', function () {
+	return gulp.src('src/*.styl')
+		.pipe(stylint())
+		.pipe(stylint.reporter())
+		.pipe(stylint.reporter('fail'));
+});
+```
+
+#### Fail-reporter options
+
+##### failOnWarning
+Type: `boolean`  
+Default: `false`
+If provided, fail the process not only on errors from `stylint`, but also on warnings.
+
+```js
+var gulp = require('gulp');
+var stylint = require('gulp-stylint');
+
+gulp.task('default', function () {
+	return gulp.src('src/*.styl')
+		.pipe(stylint())
+		.pipe(stylint.reporter())
+		.pipe(stylint.reporter('fail', { failOnWarning: true }));
+});
+```
 
 ## API
 
-### stylint(options, logger)
+### stylint(options)
 
 #### options
 type: `object`
@@ -76,27 +146,12 @@ gulp.task('default', function () {
           verbose: true
         }
       }
-    }));
+    }))
+    .pipe(stylint.reporter());
 }
 ```
 
 __NOTE__: You must install the reporter yourself. E.g. `npm i -D stylint-stylish`.
-
-##### failOnError
-
-Type: `boolean`  
-Default: `undefined`
-
-Fail the gulp-process if a warning is issued
-
-#### logger
-
-##### default logger function
-
-Type: `function`  
-Default: `console.log`
-
-Default warnings log function, you can use for example `gutil.log.bind(null, 'gulp-stylint:');`
 
 
 ## License


### PR DESCRIPTION
Breakage galore. Like discussed in #16.

Once I get rossPatton/stylint#161 merged (Have to do some work on that soon), this new exported method will replace the `reporter`-option we currently have. Should be able to do that one without breaking, though :smile: 

@danielhusar PTAL

/cc @joezimjs 
