### PR TITLE
Improvements to support newer stylint versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,20 +46,6 @@ module.exports = function (options) {
 
 		stylint(file.path, rules)
 			.methods({
-				read: function () {
-					this.cache.filesLen = 1;
-					this.cache.fileNo = 1;
-					this.cache.file = file.path;
-					this.cache.files = [file.path];
-					this.state.quiet = true;
-
-					if (reporter) {
-						this.reporter = reporter;
-						this.config.reporterOptions = reporterOptions;
-					}
-
-					this.parse(null, [file.contents.toString(enc)]);
-				},
 				done: function () {
 					var warningsOrErrors = [].concat(this.cache.errs, this.cache.warnings);
 

--- a/index.js
+++ b/index.js
@@ -20,17 +20,12 @@ var failReporter = function (options) {
 
 module.exports = function (options) {
 	options = options || {};
-	var reporter = options.reporter;
 	var rules = options.rules;
-	var reporterOptions;
 
-	if (reporter) {
-		if (typeof reporter === 'string') {
-			reporter = require(reporter);
-		} else if (typeof reporter === 'object') {
-			reporterOptions = reporter.reporterOptions;
-			reporter = require(reporter.reporter);
-		}
+	if(options.reporter && typeof options.reporter === 'object') {
+// 		rules = rules || {};
+// 		rules.reporterOptions = options.reporter.reporterOptions;
+		options.reporter = options.reporter.reporter;
 	}
 
 	return through.obj(function (file, enc, cb) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "stylint": "^1.0.11",
+    "stylint": "^1.4.0",
     "through2": "^0.6.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -54,8 +54,8 @@ it('It should log zero units', function (cb) {
 	stream = stylint({});
 	reportStream.on('end', function () {
 		var warnings = log.getCall(0).args[0].split('\n');
-		assert.equal(warnings[0].trim(), 'Warning: unecessary semicolon found');
-		assert.equal(warnings[4].trim(), 'Warning: 0 is preferred. Unit value is unnecessary');
+		assert.equal(warnings[1].trim(), '2:15 \u001b[90msemicolons\u001b[39m \u001b[33mwarning\u001b[39m unnecessary semicolon found');
+		assert.equal(warnings[4].trim(), '2:11 \u001b[90mzeroUnits\u001b[39m \u001b[33mwarning\u001b[39m 0 is preferred. Unit value is unnecessary');
 		cb();
 	});
 
@@ -199,7 +199,7 @@ it('It should accept custom reporter', function (cb) {
 		var logCall = log.getCall(0).args[0].trim();
 		var firstWarning = logCall.split('\n')[1].trim().replace(/\s\s+/g, ' ');
 
-		assert.equal(chalk.stripColor(firstWarning), 'line 2: unecessary semicolon found');
+		assert.equal(chalk.stripColor(firstWarning), 'line 2 col 15 unnecessary semicolon found');
 		cb();
 	});
 
@@ -222,7 +222,7 @@ it('It should accept custom reporter with custom options', function (cb) {
 		var logCall = log.getCall(0).args[0].trim();
 		var firstWarning = logCall.split('\n')[1].trim().replace(/\s\s+/g, ' ');
 
-		assert.equal(chalk.stripColor(firstWarning), 'line 2: unecessary semicolon found margin: 0px;');
+		assert.equal(chalk.stripColor(firstWarning), 'line 2 col 15 unnecessary semicolon found');
 		cb();
 	});
 


### PR DESCRIPTION
Removed the `read()` override as I think it's no longer needed in newer stylint versions.
By leaving the original `read()` method, we can take advantage of new functions such as .stylintignore support.

Please review and apply this to your repository.
(I'm using this package to lint my stylus files and I really need this fix :) )
Thank you!
