### PR TITLE
greenkeeping

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "stylint": "^1.0.11",
+    "stylint": "1.3.7",
     "through2": "^0.6.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -199,7 +199,7 @@ it('It should accept custom reporter', function (cb) {
 		var logCall = log.getCall(0).args[0].trim();
 		var firstWarning = logCall.split('\n')[1].trim().replace(/\s\s+/g, ' ');
 
-		assert.equal(chalk.stripColor(firstWarning), 'line 2: unecessary semicolon found');
+		assert.equal(chalk.stripColor(firstWarning), 'line 2 - unecessary semicolon found');
 		cb();
 	});
 
@@ -222,7 +222,7 @@ it('It should accept custom reporter with custom options', function (cb) {
 		var logCall = log.getCall(0).args[0].trim();
 		var firstWarning = logCall.split('\n')[1].trim().replace(/\s\s+/g, ' ');
 
-		assert.equal(chalk.stripColor(firstWarning), 'line 2: unecessary semicolon found margin: 0px;');
+		assert.equal(chalk.stripColor(firstWarning), 'line 2 - unecessary semicolon found margin: 0px;');
 		cb();
 	});
 


### PR DESCRIPTION
@SimenB As you requested in #24 , 
I made a pull request just to repair the tests.

When fixing this, I noticed that Stylint itself was not very stable.
In this PR, I used stylint@1.3.7 as it is the most stable.

beyond v1.3.7: the reporter has to be defined as a string.
beyond v1.4.1: has an issue with semicolon linting (requires a semicolon at 1:4 of valid.styl)

I am trying to find a work around to get it working with v1.4.1 but until then we'll have to do with this one.
I think we also need to file an issue on the Stylint repository as well.

Best regards.
