### PR TITLE
Made it work with Stylint@1.4.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = function (options) {
 	var reporterOptions;
 
 	if (reporter) {
+		delete options.reporter;
 		if (typeof reporter === 'string') {
 			reporter = require(reporter);
 		} else if (typeof reporter === 'object') {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "stylint": "^1.0.11",
+    "stylint": "1.3.7",
     "through2": "^0.6.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "stylint": "1.3.7",
+    "stylint": "1.4.1",
     "through2": "^0.6.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -54,7 +54,7 @@ it('It should log zero units', function (cb) {
 	stream = stylint({});
 	reportStream.on('end', function () {
 		var warnings = log.getCall(0).args[0].split('\n');
-		assert.equal(warnings[0].trim(), 'Warning: unecessary semicolon found');
+		assert.equal(warnings[0].trim(), 'Warning: unnecessary semicolon found');
 		assert.equal(warnings[4].trim(), 'Warning: 0 is preferred. Unit value is unnecessary');
 		cb();
 	});
@@ -199,7 +199,7 @@ it('It should accept custom reporter', function (cb) {
 		var logCall = log.getCall(0).args[0].trim();
 		var firstWarning = logCall.split('\n')[1].trim().replace(/\s\s+/g, ' ');
 
-		assert.equal(chalk.stripColor(firstWarning), 'line 2 - unecessary semicolon found');
+		assert.equal(chalk.stripColor(firstWarning), 'line 2 - unnecessary semicolon found');
 		cb();
 	});
 

--- a/test.js
+++ b/test.js
@@ -199,7 +199,7 @@ it('It should accept custom reporter', function (cb) {
 		var logCall = log.getCall(0).args[0].trim();
 		var firstWarning = logCall.split('\n')[1].trim().replace(/\s\s+/g, ' ');
 
-		assert.equal(chalk.stripColor(firstWarning), 'line 2: unecessary semicolon found');
+		assert.equal(chalk.stripColor(firstWarning), 'line 2 - unecessary semicolon found');
 		cb();
 	});
 
@@ -222,7 +222,7 @@ it('It should accept custom reporter with custom options', function (cb) {
 		var logCall = log.getCall(0).args[0].trim();
 		var firstWarning = logCall.split('\n')[1].trim().replace(/\s\s+/g, ' ');
 
-		assert.equal(chalk.stripColor(firstWarning), 'line 2: unecessary semicolon found margin: 0px;');
+		assert.equal(chalk.stripColor(firstWarning), 'line 2 - unecessary semicolon found margin: 0px;');
 		cb();
 	});
 

--- a/test.js
+++ b/test.js
@@ -222,7 +222,7 @@ it('It should accept custom reporter with custom options', function (cb) {
 		var logCall = log.getCall(0).args[0].trim();
 		var firstWarning = logCall.split('\n')[1].trim().replace(/\s\s+/g, ' ');
 
-		assert.equal(chalk.stripColor(firstWarning), 'line 2 - unecessary semicolon found margin: 0px;');
+		assert.equal(chalk.stripColor(firstWarning), 'line 2 - unnecessary semicolon found margin: 0px;');
 		cb();
 	});
 


### PR DESCRIPTION
I got it to work with Stylint@1.4.1 (thanks to PR #23).

But as I mentioned earlier in #26 , this is the farthest we can go.
Stylint beyond v1.4.1has an issue with semicolon linting (eg: requires a semicolon at 1:4 of valid.styl)

This pull request should cover #23 & #26 .
Please check and merge if OK.
Thank you!
