### PR TITLE
No longer using the deprecate package gulp-util, closes #34

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var through = require('through2');
 var stylint = require('stylint');
 
@@ -10,7 +10,7 @@ var failReporter = function (options) {
 
 	return through.obj(function (file, enc, cb) {
 		if (file.stylint && (file.stylint.errors || (failOnWarning && file.stylint.warnings))) {
-			return cb(new gutil.PluginError('gulp-stylint', 'Stylint failed for ' + file.relative), file);
+			return cb(new PluginError('gulp-stylint', 'Stylint failed for ' + file.relative), file);
 		}
 
 		this.push(file);
@@ -42,7 +42,7 @@ module.exports = function (options) {
 		}
 
 		if (file.isStream()) {
-			return cb(gutil.PluginError('gulp-stylint', 'Streaming not supported'), file);
+			return cb(new PluginError('gulp-stylint', 'Streaming not supported'), file);
 		}
 
 		stylint(file.path, rules)
@@ -87,7 +87,7 @@ module.exports.reporter = function (reporter, options) {
 			return failReporter(options);
 		}
 
-		throw new gutil.PluginError('gulp-stylint', reporter + ' is not a reporter');
+		throw new PluginError('gulp-stylint', reporter + ' is not a reporter');
 	}
 
 	var logger = (reporter || {}).logger || console.log;

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
     "stylus"
   ],
   "dependencies": {
-    "gulp-util": "^3.0.7",
+    "plugin-error": "^1.0.1",
     "stylint": "1.4.1",
-    "through2": "^2.0.1"
+    "through2": "^2.0.1",
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "chalk": "^1.1.3",

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var sinon = require('sinon');
 var chalk = require('chalk');
 var stylint = require('./');
@@ -17,7 +17,7 @@ function file(filenames) {
 	files.forEach(function (filename) {
 		var pathToFile = path.resolve('fixtures', filename);
 
-		stream.write(new gutil.File({
+		stream.write(new Vinyl({
 			path: pathToFile,
 			contents: fs.readFileSync(pathToFile)
 		}));


### PR DESCRIPTION
Introduced alternative packages instead of the deprecated gulp-util.